### PR TITLE
[bugfix] simplify release  workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,59 +8,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-       # Get the repository's code
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Docker meta
-        id: dockermetrics # you'll use this in the next step
-        uses: docker/metadata-action@v5
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            logzio/docker-metrics-collector
-          flavor: |
-            latest=false
-          # Docker tags based on the following events/attributes
-          
+
       - name: Build and push amd64
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.dockermetrics.outputs.tags }}-amd
-          labels: ${{ steps.dockermetrics.outputs.labels }}
-
-
-      - name: Build and push amd64 latest
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: logzio/docker-metrics-collector:latest-amd
-          labels: ${{ steps.dockermetrics.outputs.labels }}
-
-      - name: Build and push arm64 latest
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile.arm
-          platforms: linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: logzio/docker-metrics-collector:latest-arm
-          labels: ${{ steps.dockermetrics.outputs.labels }}
+          tags: |
+            logzio/docker-metrics-collector::${{ github.event.release.tag_name }}
+            logzio/docker-metrics-collector:latest
 
       - name: Build and push arm64
         uses: docker/build-push-action@v6
@@ -68,21 +38,6 @@ jobs:
           context: .
           file: ./Dockerfile.arm
           platforms: linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.dockermetrics.outputs.tags }}-arm
-          labels: ${{ steps.dockermetrics.outputs.labels }}
-
-      - name: Create manifest version
-        run: |
-          docker manifest create ${{ steps.dockermetrics.outputs.tags }} --amend ${{ steps.dockermetrics.outputs.tags }}-arm --amend ${{ steps.dockermetrics.outputs.tags }}-amd
-
-      - name: Create manifest latest
-        run: |
-          docker manifest create logzio/docker-metrics-collector:latest --amend logzio/docker-metrics-collector:latest-arm --amend logzio/docker-metrics-collector:latest-amd
-
-      - name: Push manifest latest
-        run: |
-          docker manifest push logzio/docker-metrics-collector:latest
-      - name: Push manifest version
-        run: |
-          docker manifest push ${{ steps.dockermetrics.outputs.tags }}
+          tags: |
+            logzio/docker-metrics-collector::${{ github.event.release.tag_name }}
+            logzio/docker-metrics-collector:latest


### PR DESCRIPTION
The current release workflow was over-complicated and broken this PR simplifies the process of uploading the image to docker hub