### PR TITLE
Fix: upgrade Telegraf to 1.37.1 to resolve Docker API version incompatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ RUN apt-get update && \
 	apt-get install -y wget && \
     wget https://dl.influxdata.com/telegraf/releases/telegraf_1.37.1-1_amd64.deb && \
 	dpkg -i telegraf_1.37.1-1_amd64.deb && \
-    rm telegraf_1.37.1-1_amd64.deb
+    rm telegraf_1.37.1-1_amd64.deb && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./
 COPY app.py ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3.10.5-slim
+FROM python:3.12-slim
 
 RUN apt-get update && \
 	apt-get install -y wget && \
-	wget https://dl.influxdata.com/telegraf/releases/telegraf_1.22.3-1_amd64.deb && \
-	dpkg -i telegraf_1.22.3-1_amd64.deb
+    wget https://dl.influxdata.com/telegraf/releases/telegraf_1.37.1-1_amd64.deb && \
+	dpkg -i telegraf_1.37.1-1_amd64.deb && \
+    rm telegraf_1.37.1-1_amd64.deb
 
 COPY requirements.txt ./
 COPY app.py ./

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -2,9 +2,11 @@ FROM python:3.12-slim
 
 RUN apt-get update && \
 	apt-get install -y wget && \
-    wget https://dl.influxdata.com/telegraf/releases/telegraf_1.37.1-1_amd64.deb && \
-	dpkg -i telegraf_1.37.1-1_amd64.deb && \
-    rm telegraf_1.37.1-1_amd64.deb
+    wget https://dl.influxdata.com/telegraf/releases/telegraf_1.37.1-1_arm64.deb && \
+	dpkg -i telegraf_1.37.1-1_arm64.deb && \
+    rm telegraf_1.37.1-1_arm64.deb && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./
 COPY app.py ./

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,9 +1,10 @@
-FROM python:3.10.5-slim
+FROM python:3.12-slim
 
 RUN apt-get update && \
 	apt-get install -y wget && \
-	wget https://dl.influxdata.com/telegraf/releases/telegraf_1.22.3-1_arm64.deb && \
-	dpkg -i telegraf_1.22.3-1_arm64.deb
+    wget https://dl.influxdata.com/telegraf/releases/telegraf_1.37.1-1_amd64.deb && \
+	dpkg -i telegraf_1.37.1-1_amd64.deb && \
+    rm telegraf_1.37.1-1_amd64.deb
 
 COPY requirements.txt ./
 COPY app.py ./

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ and then open [Logz.io](https://app.logz.io/#/dashboard/metrics).
 </details>
 
 ## Changelog
+- **2.0.1**:
+  - Upgrade Telegraf from 1.22.3 to 1.37.1 to fix compatibility with Docker daemon API versions >= 1.40.
+  - Upgrade Python base image from 3.10.5-slim to 3.12-slim.
 - **2.0.0**:
   - **Breaking Change**: replace `EXCLUDED_IMAGES` with `EXCLUDE_CONTAINERS`.
   - Added `INCLUDE_CONTAINERS` to filter in containers by container name.

--- a/app.py
+++ b/app.py
@@ -30,7 +30,6 @@ BASED_DATA = {
                 "container_name_include": [],
                 "container_name_exclude": [],
                 "timeout": "",
-                "total": False,
                 "docker_label_include": [],
                 "docker_label_exclude": []
             }


### PR DESCRIPTION
## Description 

This PR fixes the `inputs.docker` plugin failing on every collection interval with:

```
Error response from daemon: client version 1.24 is too old.
Minimum supported API version is 1.40, please upgrade your client to a newer version
```

The root cause is Telegraf 1.22.3 bundling a Docker client that hardcodes API version 1.24. Modern Docker daemons (20.10+) dropped support for API versions below 1.40, making the current image broken on any up-to-date host.

Upgrading Telegraf to 1.37.1 resolves the incompatibility. As a result of the upgrade, the deprecated `total` field was also removed from the `inputs.docker` config in `app.py`, which Telegraf 1.37.1 rejects at startup.

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help from somebody

> Manually tested on a VM running Docker 20.10+ — confirmed Telegraf 1.37.1 starts cleanly and metrics are collected and shipped to Logz.io without errors.